### PR TITLE
responseType should be an acceptable doXHR's option

### DIFF
--- a/MochiKit/Async.js
+++ b/MochiKit/Async.js
@@ -370,7 +370,8 @@ MochiKit.Base.update(MochiKit.Async, {
             username: undefined,
             password: undefined,
             headers: undefined,
-            mimeType: undefined
+            mimeType: undefined,
+            responseType: undefined
             */
         }, opts);
         var self = MochiKit.Async;
@@ -403,6 +404,9 @@ MochiKit.Base.update(MochiKit.Async, {
                 var value = header[1];
                 req.setRequestHeader(name, value);
             }
+        }
+        if ("responseType" in opts && "responseType" in req) {
+            req.responseType = opts.responseType;
         }
         return self.sendXMLHttpRequest(req, opts.sendContent);
     },

--- a/doc/rst/MochiKit/Async.rst
+++ b/doc/rst/MochiKit/Async.rst
@@ -586,6 +586,9 @@ Functions
         'text/xml' to force XMLHttpRequest to attempt to parse responseXML.
         Default is no override.
 
+    ``responseType``:
+        The response type for the request. Default is the empty string.
+
     *returns*:
         :mochiref:`Deferred` that will callback with the
         ``XMLHttpRequest`` instance on success

--- a/tests/test_MochiKit-Async.html
+++ b/tests/test_MochiKit-Async.html
@@ -464,11 +464,8 @@ tests.test_Async = function () {
     });
     withLock("XHR2", function () {
         var d;
-        var xhr = getXMLHttpRequest();
-        if ("responseType" in xhr) {
-            xhr.open("GET", "test_MochiKit-Async.json");
-            xhr.responseType = "arraybuffer";
-            d = sendXMLHttpRequest(xhr);
+        if ("responseType" in getXMLHttpRequest()) {
+            d = doXHR("test_MochiKit-Async.json", {responseType: "arraybuffer"});
             d.addCallback(function (xhr) {
                 is(xhr.response.byteLength, 17, "XHR2 passed");
             });


### PR DESCRIPTION
Here is a patch and some refs:
- http://www.w3.org/TR/XMLHttpRequest2/#the-responsetype-attribute
- https://developer.mozilla.org/en/DOM/XMLHttpRequest#Properties
- https://bugs.webkit.org/show_bug.cgi?id=49633
