### PR TITLE
Added new withCredentials property to MochiKit.Async.doXHR()

### DIFF
--- a/MochiKit/Async.js
+++ b/MochiKit/Async.js
@@ -371,7 +371,8 @@ MochiKit.Base.update(MochiKit.Async, {
             password: undefined,
             headers: undefined,
             mimeType: undefined,
-            responseType: undefined
+            responseType: undefined,
+            withCredentials: undefined
             */
         }, opts);
         var self = MochiKit.Async;
@@ -407,6 +408,9 @@ MochiKit.Base.update(MochiKit.Async, {
         }
         if ("responseType" in opts && "responseType" in req) {
             req.responseType = opts.responseType;
+        }
+        if (opts.withCredentials) {
+            req.withCredentials = 'true';
         }
         return self.sendXMLHttpRequest(req, opts.sendContent);
     },

--- a/doc/html/MochiKit/Async.html
+++ b/doc/html/MochiKit/Async.html
@@ -634,6 +634,8 @@ different parsing of the response in the browser, e.g. using
 'arraybuffer' to load binary data efficiently. Accepted values are
 <tt class="docutils literal">'arraybuffer'</tt>, <tt class="docutils literal">'blob'</tt>, <tt class="docutils literal">'document'</tt>, <tt class="docutils literal">'json'</tt>, and
 <tt class="docutils literal">'text'</tt>. Default is no override.</dd>
+<dt><tt class="docutils literal">withCredentials</tt>:</dt>
+<dd>Set the boolean withCredentials property of the XMLHttpRequest object, to indicate to the browser that cookies will be sent with the request, and to look for the Access-Control-Allow-Credentials header.</dd>
 <dt><em>returns</em>:</dt>
 <dd><a class="mochiref reference external" href="#fn-deferred">Deferred</a> that will callback with the
 <tt class="docutils literal">XMLHttpRequest</tt> instance on success</dd>

--- a/doc/html/MochiKit/VersionHistory.html
+++ b/doc/html/MochiKit/VersionHistory.html
@@ -62,6 +62,7 @@ PROGRESS, SCRIPT and STYLE.</li>
 <li>Fixed MochiKit.Async.XHR issue in Firefox and Chrome for local resources
 (issue #11).</li>
 <li>Added new &quot;responseType&quot; option to MochiKit.Async.doXHR().</li>
+<li>Added new &quot;withCredentials&quot; option to MochiKit.Async.doXHR().</li>
 </ul>
 <p>20XX-YY-ZZ      v1.4.3 (bug fix release)</p>
 <ul class="simple">

--- a/doc/html/MochiKit/index.html
+++ b/doc/html/MochiKit/index.html
@@ -116,6 +116,7 @@ PROGRESS, SCRIPT and STYLE.</li>
 <li>Fixed MochiKit.Async.XHR issue in Firefox and Chrome for local resources
 (issue #11).</li>
 <li>Added new &quot;responseType&quot; option to MochiKit.Async.doXHR().</li>
+<li>Added new &quot;withCredentials&quot; option to MochiKit.Async.doXHR().</li>
 </ul>
 <p>20XX-YY-ZZ      v1.4.3 (bug fix release)</p>
 <ul class="simple">

--- a/doc/rst/MochiKit/Async.rst
+++ b/doc/rst/MochiKit/Async.rst
@@ -593,6 +593,12 @@ Functions
         ``'arraybuffer'``, ``'blob'``, ``'document'``, ``'json'``, and
         ``'text'``. Default is no override.
 
+    ``withCredentials``:
+        Set the boolean withCredentials property of the XMLHttpRequest
+        object, to indicate to the browser that cookies will be sent
+        with the request, and to look for the
+        Access-Control-Allow-Credentials header.
+
     *returns*:
         :mochiref:`Deferred` that will callback with the
         ``XMLHttpRequest`` instance on success

--- a/doc/rst/MochiKit/VersionHistory.rst
+++ b/doc/rst/MochiKit/VersionHistory.rst
@@ -45,6 +45,7 @@
 - Fixed MochiKit.Async.XHR issue in Firefox and Chrome for local resources
   (issue #11).
 - Added new "responseType" option to MochiKit.Async.doXHR().
+- Added new "withCredentials" option to MochiKit.Async.doXHR().
 
 20XX-YY-ZZ      v1.4.3 (bug fix release)
 

--- a/packed/MochiKit/MochiKit.js
+++ b/packed/MochiKit/MochiKit.js
@@ -2923,6 +2923,9 @@ req.setRequestHeader(name,_32a);
 if("responseType" in opts&&"responseType" in req){
 req.responseType=opts.responseType;
 }
+if(opts.withCredentials){
+req.withCredentials="true";
+}
 return self.sendXMLHttpRequest(req,opts.sendContent);
 },_buildURL:function(url){
 if(arguments.length>1){


### PR DESCRIPTION
See https://developer.mozilla.org/en/http_access_control
and http://hacks.mozilla.org/2009/07/cross-site-xmlhttprequest-with-cors/
